### PR TITLE
Considering laser range_min when raytracing free space.

### DIFF
--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -151,9 +151,6 @@ protected:
   std::string global_frame_; ///< @brief The global frame for the costmap
   double max_obstacle_height_; ///< @brief Max Obstacle Height
 
-  double laser_min_range_; ///< @brief range_min from LaserScan message
-  double laser_max_range_; ///< @brief range_max from LaserScan message
-
   laser_geometry::LaserProjection projector_; ///< @brief Used to project laser scans into point clouds
 
   std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_; ///< @brief Used to make sure that transforms are available for each sensor

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -151,6 +151,9 @@ protected:
   std::string global_frame_; ///< @brief The global frame for the costmap
   double max_obstacle_height_; ///< @brief Max Obstacle Height
 
+  double laser_min_range_; ///< @brief range_min from LaserScan message
+  double laser_max_range_; ///< @brief range_max from LaserScan message
+
   laser_geometry::LaserProjection projector_; ///< @brief Used to project laser scans into point clouds
 
   std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_; ///< @brief Used to make sure that transforms are available for each sensor

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -423,11 +423,6 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     double wx = cloud.points[i].x;
     double wy = cloud.points[i].y;
 
-    double dist = distance(ox,oy,wx,wy);
-
-    // we can skip points which are too close
-    if (dist <= laser_min_range_) continue;
-
     //now we also need to make sure that the enpoint we're raytracing
     //to isn't off the costmap and scale if necessary
     double a = wx - ox;
@@ -460,7 +455,6 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
       wx = ox + a * t;
       wy = map_end_y - .001;
     }
-
 
     //now that the vector is scaled correctly... we'll get the map coordinates of its endpoint
     unsigned int x1, y1;

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -24,9 +24,6 @@ void ObstacleLayer::onInitialize()
   current_ = true;
   has_been_reset_ = false;
 
-  laser_min_range_ = -1;
-  laser_max_range_ = -1;
-
   global_frame_ = layered_costmap_->getGlobalFrameID();
   double transform_tolerance;
   nh.param("transform_tolerance", transform_tolerance, 0.2);

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -24,6 +24,9 @@ void ObstacleLayer::onInitialize()
   current_ = true;
   has_been_reset_ = false;
 
+  laser_min_range_ = -1;
+  laser_max_range_ = -1;
+
   global_frame_ = layered_costmap_->getGlobalFrameID();
   double transform_tolerance;
   nh.param("transform_tolerance", transform_tolerance, 0.2);
@@ -190,10 +193,15 @@ void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& mess
   sensor_msgs::PointCloud2 cloud;
   cloud.header = message->header;
 
+  laser_min_range_ = message->range_min;
+  laser_max_range_ = message->range_max;
+
+  if (!tf_->waitForTransform(global_frame_, message->header.frame_id, message->header.stamp + ros::Duration(message->scan_time), ros::Duration(0.25))) return;
+
   //project the scan into a point cloud
   try
   {
-    projector_.transformLaserScanToPointCloud(message->header.frame_id, *message, cloud, *tf_);
+    projector_.transformLaserScanToPointCloud(global_frame_, *message, cloud, *tf_);
   }
   catch (tf::TransformException &ex)
   {
@@ -302,6 +310,12 @@ void ObstacleLayer::updateBounds(double origin_x, double origin_y, double origin
         ROS_DEBUG("The point is too far away");
         continue;
       }
+
+      if (sq_dist >= laser_max_range_*laser_max_range_ /*|| sq_dist <= laser_min_range_*laser_min_range_*/)
+	  {
+	    ROS_DEBUG("The point is out of sensor range");
+	    continue;
+	  }
 
       //now we need to compute the map coordinates for the observation
       unsigned int mx, my;
@@ -421,6 +435,11 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     double wx = cloud.points[i].x;
     double wy = cloud.points[i].y;
 
+    double dist = distance(ox,oy,wx,wy);
+
+    // we can skip points which are too close
+    if (dist <= laser_min_range_) continue;
+
     //now we also need to make sure that the enpoint we're raytracing
     //to isn't off the costmap and scale if necessary
     double a = wx - ox;
@@ -454,6 +473,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
       wy = map_end_y - .001;
     }
 
+
     //now that the vector is scaled correctly... we'll get the map coordinates of its endpoint
     unsigned int x1, y1;
 
@@ -461,10 +481,23 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     if (!worldToMap(wx, wy, x1, y1))
       continue;
 
+    // compute new origin for raytracing according to laser_min_range
+    // we are going to raytrace from laser_min_range distance from sensor origin
+    double al = atan2(wy - oy, wx - ox);
+
+    double oox = laser_min_range_ * cos(al) + ox;
+    double ooy = laser_min_range_ * sin(al) + oy;
+
+    unsigned int x00 = x0;
+    unsigned int y00 = x0;
+
+    if (!worldToMap(oox, ooy, x00, y00))
+          continue;
+
     unsigned int cell_raytrace_range = cellDistance(clearing_observation.raytrace_range_);
     MarkCell marker(costmap_, FREE_SPACE);
     //and finally... we can execute our trace to clear obstacles along that line
-    raytraceLine(marker, x0, y0, x1, y1, cell_raytrace_range);
+    raytraceLine(marker, x00, y00, x1, y1, cell_raytrace_range);
 
     updateRaytraceBounds(ox, oy, wx, wy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
   }


### PR DESCRIPTION
This is extremely useful when using simulated 2D laser from Velodyne (otherwise obstacles close to robot are raytraced and robot may hit something). I'm not sure if it's useful in general but might be...

I also added correct transformation into transformLaserScanToPointCloud -> if transformed into sensor frame then it doesn't make sense (one can use simpler projector). This should be correct and may improve costmap accuracy for robots moving at higher speeds :)
