### PR TITLE
Possibility to use range_min when doing raytracing.

### DIFF
--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -168,6 +168,9 @@ protected:
   bool has_been_reset_;
   double reset_min_x_, reset_max_x_, reset_min_y_, reset_max_y_;
 
+  bool use_laser_min_range_; ///< @brief enable for use of range_min
+  double laser_min_range_; ///< @brief range_min from LaserScan message
+
   FootprintLayer footprint_layer_; ///< @brief clears the footprint in this obstacle layer.
 
 private:


### PR DESCRIPTION
This is extremely useful when using simulated 2D laser from Velodyne of similar sensor (otherwise obstacles close to robot are raytraced and robot may hit something).
